### PR TITLE
recreate collection delegate w/ new update auth

### DIFF
--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -47,3 +47,5 @@ features = ["precommit-hook", "user-hooks"]
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.
+codegen-units = 1  # Optimize for small binary size.
+lto = true  # Use link-time optimization.

--- a/program/src/errors.rs
+++ b/program/src/errors.rs
@@ -9,177 +9,219 @@ use thiserror::Error;
 #[derive(Error, Clone, Copy, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum MigrationError {
     // 0, 0x0
-    #[error("Overflow error")]
+    // #[error("Overflow error")]
+    #[error("")]
     Overflow,
 
     // 1, 0x1
-    #[error("Failed to build Migrate instruction")]
+    // #[error("Failed to build Migrate instruction")]
+    #[error("")]
     InvalidInstruction,
 
     // 2, 0x2
-    #[error("No rule set provided")]
+    // #[error("No rule set provided")]
+    #[error("")]
     NoRuleSet,
 
     // 3, 0x3
-    #[error("This feature is currently disabled")]
+    // #[error("This feature is currently disabled")]
+    #[error("")]
     FeatureDisabled,
 
     // 4, 0x4
-    #[error("Invalid unlock method")]
+    // #[error("Invalid unlock method")]
+    #[error("")]
     InvalidUnlockMethod,
 
     // Migration Errors
 
     // 5, 0x5
-    #[error("Cannot perform this action while migration is in progress")]
+    // #[error("Cannot perform this action while migration is in progress")]
+    #[error("")]
     MigrationInProgress,
 
     // 6, 0x6
-    #[error("Cannot be closed after migration has completed")]
+    // #[error("Cannot be closed after migration has completed")]
+    #[error("")]
     MigrationAlreadyCompleted,
 
     // 7, 0x7
-    #[error("Program signer is already initialized")]
+    // #[error("Program signer is already initialized")]
+    #[error("")]
     AlreadyInitialized,
 
     // 8, 0x8
-    #[error("Migration state account is locked")]
+    // #[error("Migration state account is locked")]
+    #[error("")]
     MigrationLocked,
 
     // 9, 0x9
-    #[error("Immutable metadata cannot be migrated")]
+    // #[error("Immutable metadata cannot be migrated")]
+    #[error("")]
     ImmutableMetadata,
 
     // 10, 0xA
-    #[error("Incorrect freeze authority")]
+    // #[error("Incorrect freeze authority")]
+    #[error("")]
     IncorrectFreezeAuthority,
 
     // 11, 0xB
-    #[error("Incorrect token standard: must be NonFungible")]
+    // #[error("Incorrect token standard: must be NonFungible")]
+    #[error("")]
     IncorrectTokenStandard,
 
     // 12, 0xC
-    #[error("Cannot migrate an item owned by an immutable program")]
+    // #[error("Cannot migrate an item owned by an immutable program")]
+    #[error("")]
     ImmutableProgramOwner,
 
     // Validation Errors
 
     // 13, 0xD
-    #[error("Metadata does not match mint account")]
+    // #[error("Metadata does not match mint account")]
+    #[error("")]
     MetadataMintMistmatch,
 
     // 14, 0xE
-    #[error("Token does not match the mint account")]
+    // #[error("Token does not match the mint account")]
+    #[error("")]
     TokenMintMismatch,
 
     // 15 0xF
-    #[error("Collection mint does not match stored value")]
+    // #[error("Collection mint does not match stored value")]
+    #[error("")]
     CollectionMintMismatch,
 
     // 16 0x10
-    #[error("Authority does not match the authority on the account")]
+    // #[error("Authority does not match the authority on the account")]
+    #[error("")]
     InvalidAuthority,
 
     // 17 0x11
-    #[error("No collection found on item")]
+    // #[error("No collection found on item")]
+    #[error("")]
     CollectionNotFound,
 
     // 18 0x12
-    #[error("Item is not a verified member of the collection")]
+    // #[error("Item is not a verified member of the collection")]
+    #[error("")]
     NotCollectionMember,
 
     // 19 0x13
-    #[error("Invalid token standard")]
+    // #[error("Invalid token standard")]
+    #[error("")]
     InvalidTokenStandard,
 
     // 20 0x14
-    #[error("Missing token standard")]
+    // #[error("Missing token standard")]
+    #[error("")]
     MissingTokenStandard,
 
     // 21 0x15
-    #[error("The metadata derivation does not match the mint account")]
+    // #[error("The metadata derivation does not match the mint account")]
+    #[error("")]
     InvalidMetadataDerivation,
 
     // 22 0x16
-    #[error("The edition derivation does not match the mint account")]
+    // #[error("The edition derivation does not match the mint account")]
+    #[error("")]
     InvalidEditionDerivation,
 
     // 23 0x17
-    #[error("Migration state account derivation is in correct")]
+    // #[error("Migration state account derivation is in correct")]
+    #[error("")]
     InvalidMigrationStateDerivation,
 
     // 24 0x18
-    #[error("Program signer account derivation is incorrect")]
+    // #[error("Program signer account derivation is incorrect")]
+    #[error("")]
     InvalidSignerDerivation,
 
     // 25 0x19
-    #[error("Invalid delegate record derivation")]
+    // #[error("Invalid delegate record derivation")]
+    #[error("")]
     InvalidDelegateRecordDerivation,
 
     // 26 0x1A
-    #[error("Invalid delegate")]
+    // #[error("Invalid delegate")]
+    #[error("")]
     InvalidDelegate,
 
     // 27 0x1B
-    #[error("Incorrect program owner for metadata account")]
+    // #[error("Incorrect program owner for metadata account")]
+    #[error("")]
     IncorrectMetadataProgramOwner,
 
     // 28 0x1C
-    #[error("Incorrect program owner for mint account")]
+    // #[error("Incorrect program owner for mint account")]
+    #[error("")]
     IncorrectMintProgramOwner,
 
     // 29 0x1D
-    #[error("Incorrect program owner for migration state account")]
+    // #[error("Incorrect program owner for migration state account")]
+    #[error("")]
     IncorrectMigrationStateProgramOwner,
 
     // 30 0x1E
-    #[error("Incorrect program owner for delegate record account")]
+    // #[error("Incorrect program owner for delegate record account")]
+    #[error("")]
     IncorrectDelegateRecordProgramOwner,
 
     // 31 0x1F
-    #[error("Incorrect owner for SPL token account")]
+    // #[error("Incorrect owner for SPL token account")]
+    #[error("")]
     TokenOwnerMismatch,
 
     // 32 0x20
-    #[error("Incorrect program owner for token owner account")]
+    // #[error("Incorrect program owner for token owner account")]
+    #[error("")]
     IncorrectTokenOwnerProgramOwner,
 
     // 33 0x21
-    #[error("Incorrect program owner for token owner account buffer")]
+    // #[error("Incorrect program owner for token owner account buffer")]
+    #[error("")]
     IncorrectTokenOwnerProgramBuffer,
 
     // Deserialization Errors
 
     // 34 0x22
-    #[error("Metadata did not deserialize correctly")]
+    // #[error("Metadata did not deserialize correctly")]
+    #[error("")]
     InvalidMetadata,
 
     // 35 0x23
-    #[error("Migration state did not deserialize correctly")]
+    // #[error("Migration state did not deserialize correctly")]
+    #[error("")]
     InvalidMigrationState,
 
     // 36 0x24
-    #[error("Empty migration state account")]
+    // #[error("Empty migration state account")]
+    #[error("")]
     EmptyMigrationState,
 
     // 37 0x25
-    #[error("Zeroed migration state account")]
+    // #[error("Zeroed migration state account")]
+    #[error("")]
     ZeroedMigrationState,
 
     // 38 0x26
-    #[error("Program signer did not deserialize correctly")]
+    // #[error("Program signer did not deserialize correctly")]
+    #[error("")]
     InvalidProgramSigner,
 
     // 39 0x27
-    #[error("Empty program signer account")]
+    // #[error("Empty program signer account")]
+    #[error("")]
     EmptyProgramSigner,
 
     // 40 0x28
-    #[error("Failed to deserialize UpgradeableLoaderState")]
+    // #[error("Failed to deserialize UpgradeableLoaderState")]
+    #[error("")]
     InvalidUpgradeableLoaderState,
 
     // 41 0x29
-    #[error("Authorization rules does not match the rule set stored on the state")]
+    // #[error("Authorization rules does not match the rule set stored on the state")]
+    #[error("")]
     InvalidRuleSet,
 }
 

--- a/program/src/processor/migrate/validate.rs
+++ b/program/src/processor/migrate/validate.rs
@@ -160,13 +160,9 @@ pub(crate) fn validate_eligibility(
     // so skip this check if that's the case.
     if ctx.token_owner_program_buffer_info.key != &crate::ID {
         // Do not migrate items owned by immutable programs.
-        let state: UpgradeableLoaderState = bincode::deserialize(
-            &ctx.token_owner_program_buffer_info.data.borrow(),
-        )
-        .map_err(|_| {
-            msg!("Failed to deserialize token owner program buffer");
-            MigrationError::IncorrectTokenOwnerProgramBuffer
-        })?;
+        let state: UpgradeableLoaderState =
+            bincode::deserialize(&ctx.token_owner_program_buffer_info.data.borrow())
+                .map_err(|_| MigrationError::IncorrectTokenOwnerProgramBuffer)?;
 
         match state {
             UpgradeableLoaderState::ProgramData {

--- a/program/src/processor/mod.rs
+++ b/program/src/processor/mod.rs
@@ -13,7 +13,6 @@ use solana_program::{
     account_info::{next_account_info, AccountInfo},
     clock::Clock,
     entrypoint::ProgramResult,
-    msg,
     program::invoke_signed,
     program_error::ProgramError,
     program_memory::sol_memcpy,

--- a/program/tests/start.rs
+++ b/program/tests/start.rs
@@ -12,7 +12,9 @@ use mpl_token_metadata::{
     state::{CollectionAuthorityRecord, TokenMetadataAccount},
 };
 use num_traits::FromPrimitive;
-use solana_program::{program_pack::Pack, pubkey::Pubkey, system_instruction};
+use solana_program::{
+    native_token::LAMPORTS_PER_SOL, program_pack::Pack, pubkey::Pubkey, system_instruction,
+};
 use solana_program_test::{tokio, BanksClientError, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -30,9 +32,6 @@ async fn start_migration() {
     // Create a default NFT to use as a collection.
     let mut nft = NfTest::new();
     nft.mint_default(&mut context, None).await.unwrap();
-
-    let mut nft2 = NfTest::new();
-    nft2.mint_default(&mut context, None).await.unwrap();
 
     // Create our migration state manager.
     let mut migratorr = Migratorr::new(nft.mint_pubkey());
@@ -135,16 +134,6 @@ async fn start_migration() {
     assert_eq!(delegate_record.bump, bump);
     // Record matches what was stored in the migration state.
     assert_eq!(migratorr.delegate_record(), delegate_record_pda);
-
-    context.warp_to_slot(200).unwrap();
-
-    // Running start again should fail because the migration is already in progress.
-    let err = migratorr
-        .start(&mut context, &payer, &payer, &nft)
-        .await
-        .unwrap_err();
-
-    assert_custom_error_ix!(0, err, MigrationError::MigrationInProgress);
 }
 
 #[tokio::test]
@@ -364,4 +353,277 @@ async fn zeroed_state_account() {
 
     // This will be the first error it encounters.
     assert_custom_error_ix!(0, err, MigrationError::ZeroedMigrationState);
+}
+
+#[tokio::test]
+async fn restart_migration() {
+    // We should be able to "restart" migration as long as no items have actually
+    // been migrated. This lets us update the collection delegate for a new update authority.
+    // If an item has been migrated, we don't allow this because all items must have the
+    // same collection authority as the parent and that must match the migration state.
+    let mut context = setup_context().await;
+
+    let collection_authority = context.payer.dirty_clone();
+    let collection_authority_pubkey = collection_authority.pubkey();
+
+    // Create a default NFT to use as a collection.
+    let mut collection_nft = NfTest::new();
+    collection_nft
+        .mint_default(&mut context, None)
+        .await
+        .unwrap();
+
+    // Populate the collection with two NFTs.
+    let mut nft1 = NfTest::new();
+    nft1.mint_default(&mut context, None).await.unwrap();
+    nft1.set_and_verify_collection(
+        &mut context,
+        SetAndVerifyCollectionArgs {
+            collection_metadata: collection_nft.metadata_pubkey(),
+            collection_authority: collection_authority.dirty_clone(),
+            nft_update_authority: collection_authority.pubkey(),
+            collection_mint: collection_nft.mint_pubkey(),
+            collection_master_edition_account: collection_nft.edition_pubkey().unwrap(),
+            collection_authority_record: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let mut nft2 = NfTest::new();
+    nft2.mint_default(&mut context, None).await.unwrap();
+    nft2.set_and_verify_collection(
+        &mut context,
+        SetAndVerifyCollectionArgs {
+            collection_metadata: collection_nft.metadata_pubkey(),
+            collection_authority: collection_authority.dirty_clone(),
+            nft_update_authority: collection_authority_pubkey,
+            collection_mint: collection_nft.mint_pubkey(),
+            collection_master_edition_account: collection_nft.edition_pubkey().unwrap(),
+            collection_authority_record: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    // Create our migration state manager.
+    let mut migratorr = Migratorr::new(collection_nft.mint_pubkey());
+
+    // Set up our initialize args
+    let unlock_method = UnlockMethod::Timed;
+
+    let args = InitializeArgs {
+        rule_set: None, // this defaults to the default public key
+        unlock_method: UnlockMethod::Timed,
+        collection_size: 0,
+    };
+
+    let payer = context.payer.dirty_clone();
+
+    // Initialize the migration state account on-chain
+    migratorr
+        .initialize(&mut context, &payer, &payer, &collection_nft, args)
+        .await
+        .unwrap();
+
+    // Refresh the migratorr's state from the on-chain account.
+    migratorr.refresh_state(&mut context).await.unwrap();
+
+    // Check values are as expected.
+    assert_eq!(migratorr.authority(), payer.pubkey());
+    assert_eq!(migratorr.rule_set(), Pubkey::default());
+    assert_eq!(migratorr.unlock_method(), unlock_method);
+    assert_eq!(migratorr.collection_size(), 0);
+    assert_eq!(migratorr.mint(), collection_nft.mint_pubkey());
+
+    // First we try to start the migration expecting it to fail because
+    // the current time will not be greater than or equal to the unlock
+    // time.
+    let err = migratorr
+        .start(&mut context, &payer, &payer, &collection_nft)
+        .await
+        .unwrap_err();
+
+    assert_custom_error_ix!(0, err, MigrationError::MigrationLocked);
+
+    // We need to inject the account with the state set to a timestamp
+    // that allows our migration to start.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as u64;
+
+    let mut state = migratorr.state().clone();
+    state.status.unlock_time = now as i64 - 2;
+
+    // Set the state on the account.
+    migratorr.inject_state(&mut context, state).await;
+
+    // Warp ahead to ensure account is updated.
+    context.warp_to_slot(100).unwrap();
+
+    // Update the state account on-chain. This checks the current time
+    // and updates the is_unlocked field if the wait time has passed.s
+    let update_args = UpdateArgs {
+        rule_set: None,
+        collection_size: None,
+        new_update_authority: None,
+    };
+
+    migratorr
+        .update(&mut context, &payer, update_args)
+        .await
+        .unwrap();
+
+    // Now we try to start the migration expecting it to succeed.
+    migratorr
+        .start(&mut context, &payer, &payer, &collection_nft)
+        .await
+        .unwrap();
+
+    warp100(&mut context).await;
+
+    // Refresh the migratorr's state from the on-chain account.
+    migratorr.refresh_state(&mut context).await.unwrap();
+
+    // Check values are as expected.
+    assert!(migratorr.state().status.in_progress);
+    assert!(!migratorr.state().status.is_locked);
+
+    // Ensure the collection delegate was created.
+    let (delegate_record_pda, bump) =
+        find_collection_authority_account(&migratorr.mint(), &PROGRAM_SIGNER);
+
+    // This function call panics if the account doesn't exist.
+    let delegate_record_account = get_account(&mut context, &delegate_record_pda).await;
+
+    let delegate_record =
+        CollectionAuthorityRecord::safe_deserialize(delegate_record_account.data.as_slice())
+            .expect("Failed to deserialize delegate record account");
+
+    // Check authority and bump values are as expected.
+    assert_eq!(
+        delegate_record.update_authority.unwrap(),
+        migratorr.authority()
+    );
+    assert_eq!(delegate_record.bump, bump);
+    // Record matches what was stored in the migration state.
+    assert_eq!(migratorr.delegate_record(), delegate_record_pda);
+
+    // We change the update authority of our collection parent and items
+    // and then update the authority on the migration state.
+    let new_update_authority = Keypair::new();
+    new_update_authority
+        .airdrop(&mut context, LAMPORTS_PER_SOL)
+        .await
+        .unwrap();
+
+    collection_nft
+        .set_new_update_authority(
+            &mut context,
+            SetNewUpdateAuthorityArgs {
+                update_authority: collection_authority.dirty_clone(),
+                new_update_authority: new_update_authority.pubkey(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let md = collection_nft.get_data(&mut context).await;
+
+    assert_eq!(md.update_authority, new_update_authority.pubkey());
+
+    nft1.set_new_update_authority(
+        &mut context,
+        SetNewUpdateAuthorityArgs {
+            update_authority: collection_authority.dirty_clone(),
+            new_update_authority: new_update_authority.pubkey(),
+        },
+    )
+    .await
+    .unwrap();
+
+    nft2.set_new_update_authority(
+        &mut context,
+        SetNewUpdateAuthorityArgs {
+            update_authority: collection_authority.dirty_clone(),
+            new_update_authority: new_update_authority.pubkey(),
+        },
+    )
+    .await
+    .unwrap();
+
+    migratorr.refresh_state(&mut context).await.unwrap();
+    assert_eq!(migratorr.authority(), collection_authority.pubkey());
+
+    migratorr
+        .update(
+            &mut context,
+            &payer,
+            UpdateArgs {
+                rule_set: None,
+                collection_size: None,
+                new_update_authority: Some(new_update_authority.pubkey()),
+            },
+        )
+        .await
+        .unwrap();
+
+    migratorr.refresh_state(&mut context).await.unwrap();
+    assert_eq!(migratorr.authority(), new_update_authority.pubkey());
+
+    // Migration will fail because the update authority is now not the same
+    // as the one stored in the delegate.
+
+    // Initialize the program signer
+    migratorr.init_signer(&mut context, &payer).await.unwrap();
+
+    let token_owner = context.payer.pubkey();
+
+    let err = migratorr
+        .migrate_item(
+            &mut context,
+            &payer,
+            collection_nft.mint_pubkey(),
+            token_owner,
+            &nft1,
+        )
+        .await
+        .unwrap_err();
+
+    assert_custom_error_ix!(0, err, MigrationError::InvalidDelegate);
+
+    // Delegate still has old update authority.
+    let delegate_record_account = get_account(&mut context, &delegate_record_pda).await;
+
+    let delegate_record =
+        CollectionAuthorityRecord::safe_deserialize(delegate_record_account.data.as_slice())
+            .expect("Failed to deserialize delegate record account");
+
+    assert_eq!(
+        delegate_record.update_authority.unwrap(),
+        collection_authority.pubkey(),
+    );
+
+    // Running start again should revoke the old delegate and create a new
+    // one with the new update authority.
+    migratorr
+        .start(&mut context, &payer, &new_update_authority, &collection_nft)
+        .await
+        .unwrap();
+
+    warp100(&mut context).await;
+
+    let delegate_record_account = get_account(&mut context, &delegate_record_pda).await;
+
+    let delegate_record =
+        CollectionAuthorityRecord::safe_deserialize(delegate_record_account.data.as_slice())
+            .expect("Failed to deserialize delegate record account");
+
+    assert_eq!(
+        delegate_record.update_authority.unwrap(),
+        new_update_authority.pubkey(),
+    );
+
+    // assert_custom_error_ix!(0, err, MigrationError::MigrationInProgress);
 }

--- a/program/tests/start.rs
+++ b/program/tests/start.rs
@@ -624,6 +624,4 @@ async fn restart_migration() {
         delegate_record.update_authority.unwrap(),
         new_update_authority.pubkey(),
     );
-
-    // assert_custom_error_ix!(0, err, MigrationError::MigrationInProgress);
 }


### PR DESCRIPTION
This won't work with the current implementation of `revoke_collection_authority` so would need https://github.com/metaplex-foundation/metaplex-program-library/pull/1032 merged and deployed.

Tests will need be finished and fixed after the Token Metadata PR is merged.