### PR TITLE
disable initalizing new migration state accounts

### DIFF
--- a/program/src/errors.rs
+++ b/program/src/errors.rs
@@ -223,6 +223,10 @@ pub enum MigrationError {
     // #[error("Authorization rules does not match the rule set stored on the state")]
     #[error("")]
     InvalidRuleSet,
+
+    /// 42 0x2A
+    #[error("This instruction has been deprecated")]
+    DeprecatedInstruction,
 }
 
 // Migration Error Impls

--- a/program/src/processor/initialize.rs
+++ b/program/src/processor/initialize.rs
@@ -1,134 +1,134 @@
-use mpl_token_metadata::state::TokenStandard;
+// use mpl_token_metadata::state::TokenStandard;
 
-use crate::state::{CollectionInfo, MigrationStatus};
+// use crate::state::{CollectionInfo, MigrationStatus};
 
-use super::*;
+// use super::*;
 
-pub fn initialize_migration(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo],
-    args: InitializeArgs,
-) -> ProgramResult {
-    let InitializeArgs {
-        rule_set,
-        unlock_method,
-        collection_size,
-    } = args;
+// pub fn initialize_migration(
+//     program_id: &Pubkey,
+//     accounts: &[AccountInfo],
+//     args: InitializeArgs,
+// ) -> ProgramResult {
+//     let InitializeArgs {
+//         rule_set,
+//         unlock_method,
+//         collection_size,
+//     } = args;
 
-    // Fetch accounts
-    let account_info_iter = &mut accounts.iter();
-    let payer_info = next_account_info(account_info_iter)?;
-    let authority_info = next_account_info(account_info_iter)?;
-    let collection_mint_info = next_account_info(account_info_iter)?;
-    let collection_metadata_info = next_account_info(account_info_iter)?;
-    let migration_state_info = next_account_info(account_info_iter)?;
-    let system_program_info = next_account_info(account_info_iter)?;
+//     // Fetch accounts
+//     let account_info_iter = &mut accounts.iter();
+//     let payer_info = next_account_info(account_info_iter)?;
+//     let authority_info = next_account_info(account_info_iter)?;
+//     let collection_mint_info = next_account_info(account_info_iter)?;
+//     let collection_metadata_info = next_account_info(account_info_iter)?;
+//     let migration_state_info = next_account_info(account_info_iter)?;
+//     let system_program_info = next_account_info(account_info_iter)?;
 
-    // Validate Accounts
+//     // Validate Accounts
 
-    // Both accounts must be signers, but can be the same account
-    // if collection authority is paying.
-    assert_signer(payer_info)?;
-    assert_signer(authority_info)?;
+//     // Both accounts must be signers, but can be the same account
+//     // if collection authority is paying.
+//     assert_signer(payer_info)?;
+//     assert_signer(authority_info)?;
 
-    if system_program_info.key != &solana_program::system_program::ID {
-        return Err(ProgramError::IncorrectProgramId);
-    }
+//     if system_program_info.key != &solana_program::system_program::ID {
+//         return Err(ProgramError::IncorrectProgramId);
+//     }
 
-    // Ensure that these accounts all belong together
-    // * Metadata must be derived from the mint address
-    // * Authority must be the update_authority on the metadata struct
+//     // Ensure that these accounts all belong together
+//     // * Metadata must be derived from the mint address
+//     // * Authority must be the update_authority on the metadata struct
 
-    // Properly derived Metadata account
-    assert_derivation(
-        &mpl_token_metadata::ID,
-        collection_metadata_info,
-        &[
-            b"metadata",
-            mpl_token_metadata::ID.as_ref(),
-            collection_mint_info.key.as_ref(),
-        ],
-        MigrationError::MetadataMintMistmatch,
-    )?;
+//     // Properly derived Metadata account
+//     assert_derivation(
+//         &mpl_token_metadata::ID,
+//         collection_metadata_info,
+//         &[
+//             b"metadata",
+//             mpl_token_metadata::ID.as_ref(),
+//             collection_mint_info.key.as_ref(),
+//         ],
+//         MigrationError::MetadataMintMistmatch,
+//     )?;
 
-    // This ensures the account isn't empty as the deserialization fails if the account doesn't have the correct size.
-    // It also checks that the account is actually owned by the Token Metadata program.
-    let collection_metadata = Metadata::from_account_info(collection_metadata_info)
-        .map_err(|_| MigrationError::InvalidMetadata)?;
+//     // This ensures the account isn't empty as the deserialization fails if the account doesn't have the correct size.
+//     // It also checks that the account is actually owned by the Token Metadata program.
+//     let collection_metadata = Metadata::from_account_info(collection_metadata_info)
+//         .map_err(|_| MigrationError::InvalidMetadata)?;
 
-    // Ensure that the authority is the update authority on the metadata
-    if collection_metadata.update_authority != *authority_info.key {
-        return Err(MigrationError::InvalidAuthority.into());
-    }
+//     // Ensure that the authority is the update authority on the metadata
+//     if collection_metadata.update_authority != *authority_info.key {
+//         return Err(MigrationError::InvalidAuthority.into());
+//     }
 
-    // For good measure we check that the mint is the mint on the metadata.
-    if collection_metadata.mint != *collection_mint_info.key {
-        return Err(MigrationError::MetadataMintMistmatch.into());
-    }
+//     // For good measure we check that the mint is the mint on the metadata.
+//     if collection_metadata.mint != *collection_mint_info.key {
+//         return Err(MigrationError::MetadataMintMistmatch.into());
+//     }
 
-    // The Collection NFT should be a NonFungible type, meaning it has a Master Edition.
-    if let Some(token_standard) = collection_metadata.token_standard {
-        if token_standard != TokenStandard::NonFungible {
-            return Err(MigrationError::InvalidTokenStandard.into());
-        }
-    } else {
-        // No token standard set.
-        return Err(MigrationError::MissingTokenStandard.into());
-    }
+//     // The Collection NFT should be a NonFungible type, meaning it has a Master Edition.
+//     if let Some(token_standard) = collection_metadata.token_standard {
+//         if token_standard != TokenStandard::NonFungible {
+//             return Err(MigrationError::InvalidTokenStandard.into());
+//         }
+//     } else {
+//         // No token standard set.
+//         return Err(MigrationError::MissingTokenStandard.into());
+//     }
 
-    // The migrate state account must must match the correct derivation
-    let bump = assert_derivation(
-        program_id,
-        migration_state_info,
-        &[b"migration", collection_mint_info.key.as_ref()],
-        MigrationError::InvalidMigrationStateDerivation,
-    )?;
-    let state_seeds = &[b"migration", collection_mint_info.key.as_ref(), &[bump]];
+//     // The migrate state account must must match the correct derivation
+//     let bump = assert_derivation(
+//         program_id,
+//         migration_state_info,
+//         &[b"migration", collection_mint_info.key.as_ref()],
+//         MigrationError::InvalidMigrationStateDerivation,
+//     )?;
+//     let state_seeds = &[b"migration", collection_mint_info.key.as_ref(), &[bump]];
 
-    if system_program_info.key != &solana_program::system_program::ID {
-        return Err(ProgramError::IncorrectProgramId);
-    }
+//     if system_program_info.key != &solana_program::system_program::ID {
+//         return Err(ProgramError::IncorrectProgramId);
+//     }
 
-    let unlock_time = Clock::get()?.unix_timestamp + MIGRATION_WAIT_PERIOD;
+//     let unlock_time = Clock::get()?.unix_timestamp + MIGRATION_WAIT_PERIOD;
 
-    let collection_info = CollectionInfo {
-        authority: *authority_info.key,
-        mint: *collection_mint_info.key,
-        delegate_record: Pubkey::default(),
-        rule_set: rule_set.unwrap_or_default(),
-        size: collection_size,
-    };
+//     let collection_info = CollectionInfo {
+//         authority: *authority_info.key,
+//         mint: *collection_mint_info.key,
+//         delegate_record: Pubkey::default(),
+//         rule_set: rule_set.unwrap_or_default(),
+//         size: collection_size,
+//     };
 
-    let status = MigrationStatus {
-        unlock_time,
-        is_locked: true,
-        in_progress: false,
-        items_migrated: 0,
-    };
+//     let status = MigrationStatus {
+//         unlock_time,
+//         is_locked: true,
+//         in_progress: false,
+//         items_migrated: 0,
+//     };
 
-    let migration_state = MigrationState {
-        collection_info,
-        unlock_method,
-        status,
-    };
+//     let migration_state = MigrationState {
+//         collection_info,
+//         unlock_method,
+//         status,
+//     };
 
-    let serialized_data = migration_state.try_to_vec()?;
-    let data_len = serialized_data.len();
+//     let serialized_data = migration_state.try_to_vec()?;
+//     let data_len = serialized_data.len();
 
-    mpl_utils::create_or_allocate_account_raw(
-        *program_id,
-        migration_state_info,
-        system_program_info,
-        payer_info,
-        data_len,
-        state_seeds,
-    )?;
+//     mpl_utils::create_or_allocate_account_raw(
+//         *program_id,
+//         migration_state_info,
+//         system_program_info,
+//         payer_info,
+//         data_len,
+//         state_seeds,
+//     )?;
 
-    sol_memcpy(
-        &mut migration_state_info.data.borrow_mut(),
-        serialized_data.as_slice(),
-        data_len,
-    );
+//     sol_memcpy(
+//         &mut migration_state_info.data.borrow_mut(),
+//         serialized_data.as_slice(),
+//         data_len,
+//     );
 
-    Ok(())
-}
+//     Ok(())
+// }

--- a/program/src/processor/mod.rs
+++ b/program/src/processor/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::MigrationError,
-    instruction::{InitializeArgs, MigrationInstruction, UpdateArgs},
-    state::{MigrationState, ProgramSigner, UnlockMethod, MIGRATION_WAIT_PERIOD, SPL_TOKEN_ID},
+    instruction::{MigrationInstruction, UpdateArgs},
+    state::{MigrationState, ProgramSigner, UnlockMethod, SPL_TOKEN_ID},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use mpl_token_metadata::{
@@ -32,7 +32,6 @@ mod update;
 mod validators;
 
 use close::close_migration_state;
-use initialize::initialize_migration;
 use migrate::migrate_item;
 use misc::init_signer;
 use start::start_migration;
@@ -50,8 +49,8 @@ impl Processor {
             MigrationInstruction::try_from_slice(instruction_data)?;
 
         match instruction {
-            MigrationInstruction::Initialize(args) => {
-                initialize_migration(program_id, accounts, args)
+            MigrationInstruction::Initialize(_args) => {
+                Err(MigrationError::DeprecatedInstruction.into())
             }
             MigrationInstruction::Update(args) => update_state(program_id, accounts, args),
             MigrationInstruction::Close => close_migration_state(program_id, accounts),

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -15,7 +15,6 @@ use {
 
 use crate::errors::MigrationError;
 
-pub(crate) const MIGRATION_WAIT_PERIOD: i64 = 60 * 60 * 24 * 14; // 14 days
 pub(crate) const SPL_TOKEN_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
 #[cfg_attr(feature = "serde-feature", derive(Serialize, Deserialize))]

--- a/program/tests/close.rs
+++ b/program/tests/close.rs
@@ -98,7 +98,7 @@ async fn cannot_close_in_progress_state() {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
-        .as_secs() as u64;
+        .as_secs();
     let mut state = migratorr.state().clone();
     state.status.unlock_time = now as i64 - 2;
 
@@ -186,7 +186,7 @@ async fn cannot_close_already_migrated() {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
-        .as_secs() as u64;
+        .as_secs();
     let mut state = migratorr.state().clone();
     state.status.unlock_time = now as i64 - 2;
     state.status.in_progress = false;

--- a/program/tests/initialize.rs
+++ b/program/tests/initialize.rs
@@ -1,130 +1,130 @@
-#![cfg(feature = "test-bpf")]
-pub mod utils;
+// #![cfg(feature = "test-bpf")]
+// pub mod utils;
 
-use mpl_migration_validator::{instruction::InitializeArgs, state::UnlockMethod};
-use num_traits::FromPrimitive;
-use solana_program_test::{tokio, BanksClientError};
-use solana_sdk::{
-    instruction::InstructionError, signature::Keypair, signer::Signer,
-    transaction::TransactionError,
-};
-use utils::*;
+// use mpl_migration_validator::{instruction::InitializeArgs, state::UnlockMethod};
+// use num_traits::FromPrimitive;
+// use solana_program_test::{tokio, BanksClientError};
+// use solana_sdk::{
+//     instruction::InstructionError, signature::Keypair, signer::Signer,
+//     transaction::TransactionError,
+// };
+// use utils::*;
 
-#[tokio::test]
-async fn initialize_successfully() {
-    let mut context = setup_context().await;
+// #[tokio::test]
+// async fn initialize_successfully() {
+//     let mut context = setup_context().await;
 
-    // Create a default NFT to use as a collection.
-    let mut nft = NfTest::new();
-    nft.mint_default(&mut context, None).await.unwrap();
+//     // Create a default NFT to use as a collection.
+//     let mut nft = NfTest::new();
+//     nft.mint_default(&mut context, None).await.unwrap();
 
-    // Create our migration state manager.
-    let mut migratorr = Migratorr::new(nft.mint_pubkey());
+//     // Create our migration state manager.
+//     let mut migratorr = Migratorr::new(nft.mint_pubkey());
 
-    // Set up our initialize args
-    let unlock_method = UnlockMethod::Timed;
+//     // Set up our initialize args
+//     let unlock_method = UnlockMethod::Timed;
 
-    let args = InitializeArgs {
-        rule_set: None, // this defaults to the default public key
-        unlock_method,
-        collection_size: 0,
-    };
+//     let args = InitializeArgs {
+//         rule_set: None, // this defaults to the default public key
+//         unlock_method,
+//         collection_size: 0,
+//     };
 
-    let payer = context.payer.dirty_clone();
+//     let payer = context.payer.dirty_clone();
 
-    // Initialize the migration state account on-chain
-    migratorr
-        .initialize(&mut context, &payer, &payer, &nft, args)
-        .await
-        .unwrap();
+//     // Initialize the migration state account on-chain
+//     migratorr
+//         .initialize(&mut context, &payer, &payer, &nft, args)
+//         .await
+//         .unwrap();
 
-    // Refresh the migratorr's state from the on-chain account.
-    migratorr.refresh_state(&mut context).await.unwrap();
+//     // Refresh the migratorr's state from the on-chain account.
+//     migratorr.refresh_state(&mut context).await.unwrap();
 
-    assert_eq!(migratorr.mint(), nft.mint_pubkey());
-    assert_eq!(migratorr.authority(), payer.pubkey());
-}
+//     assert_eq!(migratorr.mint(), nft.mint_pubkey());
+//     assert_eq!(migratorr.authority(), payer.pubkey());
+// }
 
-#[tokio::test]
-async fn cannot_initialize_twice() {
-    let mut context = setup_context().await;
+// #[tokio::test]
+// async fn cannot_initialize_twice() {
+//     let mut context = setup_context().await;
 
-    // Create a default NFT to use as a collection.
-    let mut nft = NfTest::new();
-    nft.mint_default(&mut context, None).await.unwrap();
+//     // Create a default NFT to use as a collection.
+//     let mut nft = NfTest::new();
+//     nft.mint_default(&mut context, None).await.unwrap();
 
-    // Create our migration state manager.
-    let migratorr = Migratorr::new(nft.mint_pubkey());
+//     // Create our migration state manager.
+//     let migratorr = Migratorr::new(nft.mint_pubkey());
 
-    // Set up our initialize args
-    let unlock_method = UnlockMethod::Timed;
+//     // Set up our initialize args
+//     let unlock_method = UnlockMethod::Timed;
 
-    let args = InitializeArgs {
-        rule_set: None, // this defaults to the default public key
-        unlock_method,
-        collection_size: 0,
-    };
+//     let args = InitializeArgs {
+//         rule_set: None, // this defaults to the default public key
+//         unlock_method,
+//         collection_size: 0,
+//     };
 
-    let payer = context.payer.dirty_clone();
+//     let payer = context.payer.dirty_clone();
 
-    // Initialize the migration state account on-chain
-    migratorr
-        .initialize(&mut context, &payer, &payer, &nft, args.clone())
-        .await
-        .unwrap();
+//     // Initialize the migration state account on-chain
+//     migratorr
+//         .initialize(&mut context, &payer, &payer, &nft, args.clone())
+//         .await
+//         .unwrap();
 
-    context.warp_to_slot(100).unwrap();
+//     context.warp_to_slot(100).unwrap();
 
-    let err = migratorr
-        .initialize(&mut context, &payer, &payer, &nft, args)
-        .await
-        .unwrap_err();
+//     let err = migratorr
+//         .initialize(&mut context, &payer, &payer, &nft, args)
+//         .await
+//         .unwrap_err();
 
-    // The account allocation call to the system program will fail with
-    // a custom error of 0 if the account already exists.
-    assert_custom_error_ix!(0, err, 0);
-}
+//     // The account allocation call to the system program will fail with
+//     // a custom error of 0 if the account already exists.
+//     assert_custom_error_ix!(0, err, 0);
+// }
 
-#[tokio::test]
-async fn init_migration_separate_authority() {
-    let mut context = setup_context().await;
+// #[tokio::test]
+// async fn init_migration_separate_authority() {
+//     let mut context = setup_context().await;
 
-    // Create an authority that is separate from the payer.
-    let authority = Keypair::new();
-    authority
-        .airdrop(&mut context, 1_000_000_000)
-        .await
-        .unwrap();
+//     // Create an authority that is separate from the payer.
+//     let authority = Keypair::new();
+//     authority
+//         .airdrop(&mut context, 1_000_000_000)
+//         .await
+//         .unwrap();
 
-    // Create a default NFT to use as a collection.
-    let mut nft = NfTest::new();
-    nft.mint_default(&mut context, Some(authority.dirty_clone()))
-        .await
-        .unwrap();
+//     // Create a default NFT to use as a collection.
+//     let mut nft = NfTest::new();
+//     nft.mint_default(&mut context, Some(authority.dirty_clone()))
+//         .await
+//         .unwrap();
 
-    // Create our migration state manager.
-    let mut migratorr = Migratorr::new(nft.mint_pubkey());
+//     // Create our migration state manager.
+//     let mut migratorr = Migratorr::new(nft.mint_pubkey());
 
-    // Set up our initialize args
-    let unlock_method = UnlockMethod::Timed;
+//     // Set up our initialize args
+//     let unlock_method = UnlockMethod::Timed;
 
-    let args = InitializeArgs {
-        rule_set: None, // this defaults to the default public key
-        unlock_method,
-        collection_size: 0,
-    };
+//     let args = InitializeArgs {
+//         rule_set: None, // this defaults to the default public key
+//         unlock_method,
+//         collection_size: 0,
+//     };
 
-    let payer = context.payer.dirty_clone();
+//     let payer = context.payer.dirty_clone();
 
-    // Initialize the migration state account on-chain
-    migratorr
-        .initialize(&mut context, &payer, &authority, &nft, args)
-        .await
-        .unwrap();
+//     // Initialize the migration state account on-chain
+//     migratorr
+//         .initialize(&mut context, &payer, &authority, &nft, args)
+//         .await
+//         .unwrap();
 
-    // Refresh the migratorr's state from the on-chain account.
-    migratorr.refresh_state(&mut context).await.unwrap();
+//     // Refresh the migratorr's state from the on-chain account.
+//     migratorr.refresh_state(&mut context).await.unwrap();
 
-    assert_eq!(migratorr.mint(), nft.mint_pubkey());
-    assert_eq!(migratorr.authority(), authority.pubkey());
-}
+//     assert_eq!(migratorr.mint(), nft.mint_pubkey());
+//     assert_eq!(migratorr.authority(), authority.pubkey());
+// }

--- a/program/tests/start.rs
+++ b/program/tests/start.rs
@@ -78,7 +78,7 @@ async fn start_migration() {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
-        .as_secs() as u64;
+        .as_secs();
 
     let mut state = migratorr.state().clone();
     state.status.unlock_time = now as i64 - 2;
@@ -451,7 +451,7 @@ async fn restart_migration() {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
-        .as_secs() as u64;
+        .as_secs();
 
     let mut state = migratorr.state().clone();
     state.status.unlock_time = now as i64 - 2;

--- a/program/tests/utils/migratorr.rs
+++ b/program/tests/utils/migratorr.rs
@@ -411,7 +411,7 @@ impl Migratorr {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
-            .as_secs() as u64;
+            .as_secs();
 
         let mut state = self.state().clone();
         state.status.unlock_time = now as i64 - 2;


### PR DESCRIPTION
To be merged and deployed on May 10th to prevent creating new migration states.